### PR TITLE
feat: 쿠키에 refresh token 저장, 인증, 관리

### DIFF
--- a/src/auth/strategies/refresh-token.strategy.ts
+++ b/src/auth/strategies/refresh-token.strategy.ts
@@ -13,14 +13,18 @@ export class RefreshTokenStrategy extends PassportStrategy(Strategy, 'jwt-refres
     private readonly authService: AuthService,
   ) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
-      secretOrKey: configService.get<string>('JWT_REFRESH_TOKEN_SECRET_KEY'),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => {
+          return request?.cookies?.refresh;
+        },
+      ]),
+      secretOrKey: configService.get('JWT_REFRESH_TOKEN_SECRET_KEY'),
       passReqToCallback: true,
     });
   }
 
   async validate(req: Request, payload: JwtDto) {
-    const refreshToken = req?.get('Authorization').replace('Bearer', '').trim();
+    const refreshToken = req.cookies?.refresh;
     return await this.authService.validateRefreshToken(refreshToken, payload.sub);
   }
 }


### PR DESCRIPTION
## 🔍 What is this PR?

쿠키에 refresh token을 저장, 인증, 관리를 하는 코드를 추가했습니다.

## 🙇 Changes

**어떤 부분이 변경되었는지 설명해주세요.**

- refresh token을 query로 보냈는데 쿠키에 저장을 해서 보내는 방식으로 변경되었습니다.
- refresh token 인증도 쿠키에서 refresh token 값을 꺼내 인증하는 방식으로 변경되었습니다.

## 📸 스크린 샷

**어떤 점이 달라졌는지 알 수 있게끔 스크린 샷을 첨부해주세요.**

## ✅ 체크 리스트

- [ ] **테스트 계획 또는 완료된 사항의 체크리스트를 작성해주세요.**
